### PR TITLE
Correct require path and typos in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Dependency Status](https://gemnasium.com/badges/github.com/izumin5210/rspec-cheki.svg)](https://gemnasium.com/github.com/izumin5210/rspec-cheki)
 [![Inline docs](http://inch-ci.org/github/izumin5210/rspec-cheki.svg?branch=master&style=shields)](http://inch-ci.org/github/izumin5210/rspec-cheki)
 
-Support snapshot testing, inspired [Jest](https://facebook.github.io/jest/).
+Support snapshot testing, inspired by [Jest](https://facebook.github.io/jest/).
 
 ```ruby
 expect(response.body).to match_snapshot
@@ -33,10 +33,10 @@ Or install it yourself as:
 
 ## Usage
 
-Requrie `rspec-cheki` from your `spec_helper.rb`.
+Require `rspec/cheki` from your `spec_helper.rb`.
 
 ```ruby
-requrie 'rspec-cheki'
+require 'rspec/cheki'
 ```
 
 ### `match_snapshot` matcher
@@ -50,7 +50,7 @@ expect(response.body).to say_cheese
 
 ### Update snapshots
 
-Run rspec with `UPDATE_SNAPSHOTS=1` to update snapshtos files.
+Run rspec with `UPDATE_SNAPSHOTS=1` to update snapshot files.
 
 ```
 $ UPDATE_SNAPSHOTS=1 rspec
@@ -70,4 +70,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/[USERN
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/rspec-cheki.gemspec
+++ b/rspec-cheki.gemspec
@@ -1,5 +1,5 @@
 # coding: utf-8
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "rspec/cheki/version"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "rspec/cheki"
 require "rspec/its"
 require "fakefs/spec_helpers"


### PR DESCRIPTION
Hi,

Thanks a lot for this gem! I find snapshot testing super helpful, and I was very happy to find your gem implementing it for rspec. :)

I could not require your gem by following the readme, only after I changed `require 'rspec-cheki'` to `require 'rspec/cheki'` the gem was found. I'm not sure if this is something specific to my installation or a problem introduced by newer versions of bundler/ruby/you-name-it, but in case it isn't and was in fact mistakenly mistyped in the readme, here's a PR to fix it. I've also corrected some typos while already at it. :)

If you're generally interested in feedback from my using your gem in the next weeks, let me know, I'll gladly open an issue or two if I find something that might be interesting to improve. :)

Thanks again!
Simon